### PR TITLE
Minor tweaks

### DIFF
--- a/vs/AlfredTrx/AlfredTrx/AlfredTaskRunner.cs
+++ b/vs/AlfredTrx/AlfredTrx/AlfredTaskRunner.cs
@@ -28,7 +28,7 @@ namespace AlfredTrx
         {
             _icon = new BitmapImage(new Uri(@"pack://application:,,,/AlfredTRX;component/Resources/AlfredBatman.png"));
             _options = new List<ITaskRunnerOption>();
-            _options.Add(new TaskRunnerOption("Verbose", PkgCmdIDList.cmdidVerboseTaskRunners, GuidList.guidTaskRunnerExplorerExtensionsCmdSet, true, "-verbose"));
+            _options.Add(new TaskRunnerOption("Verbose", PkgCmdIDList.cmdidVerboseTaskRunners, GuidList.guidTaskRunnerExplorerExtensionsCmdSet, false, "-verbose"));
         }
 
 

--- a/vs/AlfredTrx/AlfredTrx/AlfredTrx.csproj
+++ b/vs/AlfredTrx/AlfredTrx/AlfredTrx.csproj
@@ -13,7 +13,8 @@
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyOriginatorKeyFile>Key.snk</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>
+    </AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -73,7 +74,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="Key.snk" />
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>

--- a/vs/AlfredTrx/AlfredTrx/Helpers/TaskRunnerConfig.cs
+++ b/vs/AlfredTrx/AlfredTrx/Helpers/TaskRunnerConfig.cs
@@ -27,4 +27,28 @@ namespace AlfredTrx.Helpers
             return _rootNodeIcon;
         }
     }
+
+    public class TaskRunnerConfig : TaskRunnerConfigBase
+    {
+        private ImageSource _rootNodeIcon;
+
+        public TaskRunnerConfig(ITaskRunnerCommandContext context, ITaskRunnerNode hierarchy, IPersistTaskRunnerBindings persister)
+            : base(context, hierarchy)
+        {
+            BindingsPersister = persister;
+        }
+
+        public TaskRunnerConfig(ITaskRunnerCommandContext context, ITaskRunnerNode hierarchy, IPersistTaskRunnerBindings persister, ImageSource rootNodeIcon)
+            : this(context, hierarchy, persister)
+        {
+            _rootNodeIcon = rootNodeIcon;
+        }
+
+        protected override IPersistTaskRunnerBindings BindingsPersister { get; }
+
+        protected override ImageSource LoadRootNodeIcon()
+        {
+            return _rootNodeIcon;
+        }
+    }
 }

--- a/vs/AlfredTrx/AlfredTrx/PowershellBindingsPersister.cs
+++ b/vs/AlfredTrx/AlfredTrx/PowershellBindingsPersister.cs
@@ -21,6 +21,7 @@ namespace AlfredTrx
             }
 
             int openIndex = line.IndexOf("<binding", hashIndex);
+            hashIndex = line.LastIndexOf('#', openIndex);
 
             if (openIndex < 0)
             {


### PR DESCRIPTION
Fix bindings consuming whole comment when placed after an existing comment
Deleted SNK
Changed "verbose" option to be unchecked by default
Added configuration base that doesn't accept the persister as a generic parameter
